### PR TITLE
🔀 로그인과 refreshToken 재발급 수정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,8 +64,8 @@ model application_details {
 }
 
 model refresh_token {
-  user_idx      BigInt @id
-  refresh_token String @db.VarChar(500)
+  user_idx      BigInt  @id
+  refresh_token String? @db.VarChar(500)
 }
 
 model admin {


### PR DESCRIPTION
## 개요 💡

> 로그인과 refreshToken 재발급 부분에서 refreshToken을 저장하지 않아 refreshToken 재발급을 할 수 없는 버그가 있었습니다.

## 작업 내용 ⌨️

> `saveRefresh`를 만들어 refreshToken을 로그인과 재발급 부분에서 동작하게 만들었습니다.
> passport에서도 hash화된 refreshToken을 `bcrypt.compareSync`로 검증하는 부분을 추가했습니다.
> db에서 `refresh_token` 컬럼에 `null`을 넣을 수 있게 바꾸었습니다.