### PR TITLE
🔀 cookie option 변경

### DIFF
--- a/apps/admin/src/auth/auth.controller.ts
+++ b/apps/admin/src/auth/auth.controller.ts
@@ -22,7 +22,7 @@ export class AuthController {
     httpOnly: true,
     domain: this.configService.get(ENV.ADMIN_DOMAIN),
     secure: process.env.NODE_ENV === 'prod',
-    sameSite: 'lax',
+    sameSite: 'none',
   };
 
   @Public()


### PR DESCRIPTION
## 개요 💡

> 다른 도메인 간의 쿠키 요청은 `SameSite=None; secure;`에서만 된다고 합니다.

[참고한 자료](https://github.com/themoment-team/hello-gsm-back/compare/fix/adminCookie?expand=1)

## 작업 내용 ⌨️

> `sameSite` option을 `none`으로 변경했습니다